### PR TITLE
ENH: change arokem to yourbucket

### DIFF
--- a/_episodes/02-consoles.md
+++ b/_episodes/02-consoles.md
@@ -23,14 +23,14 @@ iTerm/Terminal on the Mac or
 
 ### Logging in to the AWS Console & Creating an EC2 instance
 
-Log in to https://uwescience.signin.aws.amazon.com/console. Use the IAM
-Username and Password that was provided to you Account ID/Alias:
+Log in to the https://uwescience.signin.aws.amazon.com/console.
+Use the IAM Username and Password that was provided to you Account ID/Alias:
 uwescience
 
 Once you are logged on the the console, on the right top hand corner next
-to your IAM username you will see a region. Please make sure that
-US-East(Ohio) is selected from the drop down menu. We will be solely
-using the Ohio region for Neurohackweek cloud work.
+to your IAM username you will see a region.
+Please make sure that US-East(Ohio) is selected from the drop down menu. 
+We will be solely using the Ohio region for Neurohackweek cloud work.
 
 Under Build a Solution, select Launch A Virtual Machine
 
@@ -44,14 +44,17 @@ Select 't2.micro', click Next: Configure Instance Details
 
 #### Step 3: Configure Instance Details
 
-The only thing you will need to change is the IAM role. Select
-*neurohacks3fullaccess* from the Drop Down List. IAM roles allow AWS
-resources to communicate with one another without the use of access keys.
+The only thing you will need to change is the IAM role. 
+Select
+*neurohacks3fullaccess* from the Drop Down List. 
+IAM roles allow AWS resources to communicate with one 
+another without the use of access keys.
 Click Next: Add Storage
 
 #### Step 4: Add Storage
 
-Change the Size to 25GiB. Click Next: Add Tags
+Change the Size to 25GiB. 
+Click Next: Add Tags
 
 #### Step 5: Add Tags
 
@@ -59,7 +62,8 @@ Key - Name, Value - neurohack-amandatan
 Key - Owner, Value - neurohack-amandatan
 
 Please append *neurohack* to your IAM username for all AWS resources you
-provision. This helps us keep track of the resources.
+provision. 
+This helps us keep track of the resources.
 
 #### Step 6: Configure Security Group
 
@@ -73,8 +77,8 @@ Click Launch
 The Select an existing key pair or Create a new key pair window will pop
 up.
 
-From the drop down menu, select Create a new key pair. The key pair name
-will be *neurohack-IAMusername*
+From the drop down menu, select Create a new key pair. 
+The key pair name will be *neurohack-IAMusername*
 
 Make sure to Download Key Pair. Note where the Key Pair is saved (for
 Mac/Linux, it is usually automatically saved to your Downloads folder).
@@ -85,24 +89,26 @@ into the hub using the upload button.
 Once you have saved the Key Pair (e.g. neurohack-amandatan.pem), click
 Launch Instances.
 
-You will see the Launch Status screen. Click on ID number associated with
-your instance.
+You will see the Launch Status screen. 
+Click on ID number associated with your instance.
 
-You will be taken to the EC2 dashboard. Look for the IPv4 Public IP. You
-will need this IP to ssh into your instance.
+You will be taken to the EC2 dashboard. 
+Look for the IPv4 Public IP. 
+You will need this IP to ssh into your instance.
 
 ### Storage on the cloud: S3
 
-In S3, we can create "buckets" with data. These are like folders on a
-computer, except they're not really on any computer that we can access,
-so we'll have to download them onto some other computers to do any
-computations with the data.
+In S3, we can create "buckets" with data. 
+These are like folders on a computer, except they're not really on
+any computer that we can access, so we'll have to download them
+onto some other computers to do any computations with the data.
 
 One of the main things to remember about S3 is that storing data on S3 is
 not very expensive ($0.024/GB/month) but you can end up paying quite a
 bit if you move the data out of the AWS data-center in which your data is
-stored. One way to avoid that is to do all your compute in that
-data-center. That is, bring your compute to where the data is.
+stored. 
+One way to avoid that is to do all your compute in that data-center. 
+That is, bring your compute to where the data is.
 
 That means that you will want to keep an eye on the "region" in which the
 data is stored (in our case Ohio) and only download the data to machines
@@ -150,7 +156,7 @@ contents again.
 
 To copy files from one s3 bucket to another:
 
-```  aws s3 cp s3://neurohack-amandatan s3://neurohack-arokem --recursive```
+```  aws s3 cp s3://neurohack-amandatan s3://neurohack-yourbucket --recursive```
 
 List contents of your bucket:
 


### PR DESCRIPTION
The command:
`aws s3 cp s3://neurohack-amandatan s3://neurohack-arokem --recursive` was a little confusing to me (e.g. which name should I replace with my own), so this pull request changes the name to `yourbucket`, the name used previously.

I also changed lines so that each sentence gets at least one line (for easier editing)